### PR TITLE
FIX: add `mut` constraint for SecureClaim's user for updating rewards_cliame…

### DIFF
--- a/programs/bump-seed-canonicalization/src/lib.rs
+++ b/programs/bump-seed-canonicalization/src/lib.rs
@@ -167,6 +167,7 @@ pub struct InsecureClaim<'info> {
 #[derive(Accounts)]
 pub struct SecureClaim<'info> {
     #[account(
+        mut,
         seeds = [payer.key().as_ref()],
         bump = user.bump,
         constraint = !user.rewards_claimed @ ClaimError::AlreadyClaimed,


### PR DESCRIPTION
- FIX: add `mut` constraint for SecureClaim's user for update `rewards_cliamed` flag in `claim_secure` function, otherwise, the `rewards_claimed` flag can't be updated to `true`,  attacker can re-claim !
```rust
pub struct SecureClaim<'info> {
    #[account(
        mut, // FIX  with mut
        seeds=[payer.key().as_ref()],
        bump,
        constraint = user.rewards_claimed == false @ClaimError::AlreadyClaimed,
        constraint = user.auth == payer.key(),
    )]
    pub user: Account<'info, UserSecure>,
```